### PR TITLE
Add minimal React frontend with live scan stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,18 @@ This repository contains the early backend scaffold for NetScan Orchestrator Nex
 - Added a tiny XML summary parser to showcase post-processing.
 - Documented run instructions and Docker capability notes.
 
+**Frontend**
+- Added a Vite + React + TypeScript UI with Tailwind and TanStack Query.
+- Lists projects, allows starting scans, and streams live output via WebSocket.
+
 **Docs**
-- This changelog, TODO list, and runbook captured here.
+- This changelog, TODO list, runbook, and frontend quickstart captured here.
 
-## What's still to build
+## Install & Run
 
-1. Frontend minimal UI (Vite + React + Tailwind + TanStack Query).
-2. Persistence polish with transactional batch finish and optional Postgres.
-3. Resilience features such as retry/resplit and supervisor for recovery.
-4. Parsing: proper Nmap XML into `host_results`/`port_results` tables.
-5. Auth & multi-user support.
-6. CLI wrapper using Typer.
-
-## How to run (local)
+### Backend
+- Python 3.11+, Nmap installed
+- Setup:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -32,28 +31,40 @@ pip install -U pip
 pip install fastapi uvicorn[standard] sqlalchemy aiosqlite alembic pydantic
 mkdir -p data/outputs
 alembic revision --autogenerate -m "init" && alembic upgrade head
-uvicorn backend.app:app --reload
+uvicorn backend.app:app --reload --port 8000
 ```
 
-### Docker (SYN scans)
+### Frontend
+- Node 18+
+- Setup:
 
-Run as root **or** add `--cap-add=NET_RAW --cap-add=NET_ADMIN`. If capabilities aren’t present, the runner will fall back to `-sT`.
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
-## API events (WebSocket)
+If your backend is on a different origin, create `.env` in `frontend/` with `VITE_API_BASE=http://localhost:8000`.
 
-Events broadcast today (JSON):
-- `{"event":"connected","scan_id":<id>}`
-- `{"event":"batch_start","batch_id":<id>,"targets":[...]}`
-- `{"event":"line","batch_id":<id>,"line":"..."}`
-- `{"event":"batch_complete","batch_id":<id>,"summary":{hosts_up,open_ports}}`
-- `{"event":"scan_complete","scan_id":<id>}`
+## Architecture
+- **Backend:** FastAPI REST API and WebSocket endpoints backed by an async subprocess runner that orchestrates Nmap scans.
+- **Data model:** Projects → Scans → Batches with raw results saved for each batch.
+- **Frontend:** Vite + React + TypeScript, styled with Tailwind. TanStack Query handles data fetching and caching. WebSocket events provide live log streaming.
 
-## Next tasks (detailed TODO)
+## Realtime protocol
+JSON events broadcast over `/ws/scans/{id}`:
+- `{ "event":"connected", "scan_id":<id> }`
+- `{ "event":"batch_start", "batch_id":<id>, "targets":[...] }`
+- `{ "event":"line", "batch_id":<id>, "line":"..." }`
+- `{ "event":"batch_complete", "batch_id":<id>, "summary":{hosts_up,open_ports} }`
+- `{ "event":"scan_complete", "scan_id":<id> }`
 
-- Frontend skeleton.
-- DB lifecycle improvements.
-- XML parsing.
-- Resplit logic.
-- Startup recovery.
-- Dockerfile.
-- CLI.
+## Docker (SYN scans)
+Run as root **or** add `--cap-add=NET_RAW --cap-add=NET_ADMIN`. If capabilities aren’t present, the runner falls back to `-sT`.
+
+## Roadmap
+- Persistence polish with transactional batch finish and optional Postgres.
+- Resilience features such as retry/resplit and supervisor for recovery.
+- Parsing: proper Nmap XML into `host_results`/`port_results` tables.
+- Auth & multi-user support.
+- CLI wrapper using Typer.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>NetScan Orchestrator Next — UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 5173"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.4",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.45",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import LiveLog from "./components/LiveLog";
+import { createProject, listProjects, startScan, type Project } from "./lib/api";
+
+export default function App() {
+  const qc = useQueryClient();
+  const [selectedProject, setSelectedProject] = useState<number | null>(null);
+  const [targetsText, setTargetsText] = useState("");
+  const [flags, setFlags] = useState("-T4 -Pn -sS");
+  const [chunkSize, setChunkSize] = useState(256);
+  const [concurrency, setConcurrency] = useState(6);
+  const [activeScanId, setActiveScanId] = useState<number | null>(null);
+
+  const projectsQ = useQuery({
+    queryKey: ["projects"],
+    queryFn: listProjects,
+    staleTime: 5_000,
+  });
+
+  const createProjectM = useMutation({
+    mutationFn: (input: { name: string; description?: string }) =>
+      createProject(input.name, input.description),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["projects"] }),
+  });
+
+  const startScanM = useMutation({
+    mutationFn: async () => {
+      if (!selectedProject) throw new Error("No project selected");
+      const targets = targetsText
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const nmap_flags = flags.split(/\s+/).filter(Boolean);
+      const res = await startScan({
+        project_id: selectedProject,
+        nmap_flags,
+        targets,
+        chunk_size: chunkSize,
+        concurrency,
+      });
+      return res;
+    },
+    onSuccess: (res) => setActiveScanId(res.scan_id),
+  });
+
+  const projects = useMemo<Project[]>(() => projectsQ.data ?? [], [projectsQ.data]);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">NetScan Orchestrator — UI (MVP)</h1>
+        <a className="btn" href="https://github.com/cornish337/NetScanOrchestrator-NG" target="_blank" rel="noreferrer">
+          Repo
+        </a>
+      </header>
+
+      {/* Projects */}
+      <section className="card space-y-4">
+        <h2 className="text-lg font-semibold">Projects</h2>
+        {projectsQ.isLoading ? (
+          <div>Loading projects…</div>
+        ) : projectsQ.isError ? (
+          <div className="text-red-600">Failed to load projects</div>
+        ) : (
+          <>
+            {projects.length === 0 ? (
+              <div className="text-slate-500">No projects yet — create one below.</div>
+            ) : (
+              <div className="grid gap-2">
+                {projects.map((p) => (
+                  <label key={p.id} className="flex items-center gap-3">
+                    <input
+                      type="radio"
+                      name="project"
+                      checked={selectedProject === p.id}
+                      onChange={() => setSelectedProject(p.id)}
+                    />
+                    <div>
+                      <div className="font-medium">{p.name}</div>
+                      {p.description && <div className="text-sm text-slate-500">{p.description}</div>}
+                    </div>
+                  </label>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+
+        <CreateProject onCreate={(name, description) => createProjectM.mutate({ name, description })} />
+      </section>
+
+      {/* Start Scan */}
+      <section className="card space-y-4">
+        <h2 className="text-lg font-semibold">Start Scan</h2>
+
+        <div className="grid md:grid-cols-2 gap-4">
+          <div>
+            <label className="label">Nmap flags</label>
+            <input className="input" value={flags} onChange={(e) => setFlags(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="label">Chunk size</label>
+              <input
+                className="input"
+                type="number"
+                value={chunkSize}
+                onChange={(e) => setChunkSize(Number(e.target.value))}
+              />
+            </div>
+            <div>
+              <label className="label">Concurrency</label>
+              <input
+                className="input"
+                type="number"
+                value={concurrency}
+                onChange={(e) => setConcurrency(Number(e.target.value))}
+              />
+            </div>
+          </div>
+          <div className="md:col-span-2">
+            <label className="label">Targets (one per line: IP/host or CIDR)</label>
+            <textarea
+              className="input min-h-[120px]"
+              placeholder="192.0.2.10
+198.51.100.0/24"
+              value={targetsText}
+              onChange={(e) => setTargetsText(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            className="btn"
+            disabled={startScanM.isPending || !selectedProject || !targetsText.trim()}
+            onClick={() => startScanM.mutate()}
+          >
+            {startScanM.isPending ? "Starting…" : "Start Scan"}
+          </button>
+          {startScanM.isError && <div className="text-red-600">Start failed</div>}
+          {activeScanId && <div className="text-slate-600">Active scan: #{activeScanId}</div>}
+        </div>
+      </section>
+
+      {/* Live log */}
+      {activeScanId && (
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">Live Stream</h2>
+          <LiveLog scanId={activeScanId} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+function CreateProject(props: { onCreate: (name: string, description?: string) => void }) {
+  const [name, setName] = useState("");
+  const [desc, setDesc] = useState("");
+
+  return (
+    <div className="flex items-end gap-3">
+      <div className="grow">
+        <label className="label">New project name</label>
+        <input className="input" value={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div className="grow">
+        <label className="label">Description (optional)</label>
+        <input className="input" value={desc} onChange={(e) => setDesc(e.target.value)} />
+      </div>
+      <button
+        className="btn"
+        onClick={() => {
+          if (!name.trim()) return;
+          props.onCreate(name.trim(), desc.trim() || undefined);
+          setName(""); setDesc("");
+        }}
+      >
+        Create
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/LiveLog.tsx
+++ b/frontend/src/components/LiveLog.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from "react";
+import { wsUrl } from "../lib/api";
+import type { WSEvent } from "../lib/types";
+
+export default function LiveLog({ scanId }: { scanId: number }) {
+  const [lines, setLines] = useState<string[]>([]);
+  const wsRef = useRef<WebSocket | null>(null);
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket(wsUrl(`/ws/scans/${scanId}`));
+    wsRef.current = ws;
+
+    ws.onmessage = (ev) => {
+      try {
+        const msg: WSEvent = JSON.parse(ev.data);
+        if (msg.event === "line") {
+          setLines((prev) => [...prev, `[batch ${msg.batch_id}] ${msg.line}`].slice(-2000));
+        } else if (msg.event === "batch_start") {
+          setLines((p) => [...p, `▶ batch ${msg.batch_id} started (${msg.targets.length} targets)`]);
+        } else if (msg.event === "batch_complete") {
+          setLines((p) => [
+            ...p,
+            `✔ batch ${msg.batch_id} complete — hosts_up=${msg.summary.hosts_up}, open_ports=${msg.summary.open_ports}`,
+          ]);
+        } else if (msg.event === "scan_complete") {
+          setLines((p) => [...p, `🏁 scan ${msg.scan_id} complete`]);
+        } else if (msg.event === "connected") {
+          setLines((p) => [...p, `connected to scan ${msg.scan_id}`]);
+        }
+      } catch {
+        setLines((prev) => [...prev, ev.data]);
+      }
+      endRef.current?.scrollIntoView({ behavior: "smooth" });
+    };
+
+    ws.onerror = () => setLines((p) => [...p, "⚠ websocket error"]);
+    ws.onclose = () => setLines((p) => [...p, "ℹ disconnected"]);
+
+    return () => ws.close();
+  }, [scanId]);
+
+  return (
+    <div className="card max-h-[40vh] overflow-auto text-sm font-mono leading-tight">
+      {lines.map((l, i) => (
+        <div key={i} className="whitespace-pre-wrap">{l}</div>
+      ))}
+      <div ref={endRef} />
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* tiny helpers */
+:root { color-scheme: light dark; }
+body { @apply bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100; }
+.card { @apply rounded-2xl shadow p-4 bg-white dark:bg-slate-900 border border-slate-200/60 dark:border-slate-800; }
+.btn { @apply inline-flex items-center gap-2 rounded-xl px-3 py-2 border border-slate-300 dark:border-slate-700 hover:bg-slate-100/60 dark:hover:bg-slate-800/70; }
+.input { @apply rounded-xl px-3 py-2 border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 w-full; }
+.label { @apply text-sm font-medium text-slate-600 dark:text-slate-300; }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import "./index.css";
+
+const qc = new QueryClient();
+
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={qc}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- add Vite/React/TypeScript frontend with projects list, scan form, and live WebSocket log
- include API helpers and Tailwind styling
- document backend and frontend setup plus realtime protocol and roadmap

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tanstack%2freact-query)*
- `npm run build` *(fails: Cannot find module 'react')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a2507133dc8321b504d221e1088970