### PR TITLE
feat: add nmap runner component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
+!frontend/src/lib/**
 lib64/
 parts/
 sdist/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import LiveLog from "./components/LiveLog";
+import NmapRunner from "./components/NmapRunner";
 import { createProject, listProjects, startScan, type Project } from "./lib/api";
 
 export default function App() {
@@ -143,6 +144,9 @@ export default function App() {
           {activeScanId && <div className="text-slate-600">Active scan: #{activeScanId}</div>}
         </div>
       </section>
+
+      {/* Nmap runner */}
+      <NmapRunner />
 
       {/* Live log */}
       {activeScanId && (

--- a/frontend/src/components/NmapRunner.tsx
+++ b/frontend/src/components/NmapRunner.tsx
@@ -1,0 +1,54 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { runNmap } from "../lib/api";
+
+export default function NmapRunner() {
+  const [flags, setFlags] = useState("-T4 -Pn -sV");
+  const [targets, setTargets] = useState("");
+
+  const runM = useMutation({
+    mutationFn: async () => {
+      const flagsArr = flags.split(/\s+/).filter(Boolean);
+      const targetsArr = targets.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      return runNmap({ flags: flagsArr, targets: targetsArr });
+    },
+  });
+
+  const lines = runM.data ? runM.data.stdout.split(/\r?\n/).slice(-2000) : [];
+
+  return (
+    <section className="card space-y-4">
+      <h2 className="text-lg font-semibold">Run Nmap</h2>
+      <div className="grid md:grid-cols-2 gap-4">
+        <div>
+          <label className="label">Flags</label>
+          <input className="input" value={flags} onChange={(e) => setFlags(e.target.value)} />
+        </div>
+        <div className="md:col-span-2">
+          <label className="label">Targets</label>
+          <textarea
+            className="input min-h-[80px]"
+            placeholder="scanme.nmap.org\n192.0.2.10"
+            value={targets}
+            onChange={(e) => setTargets(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          className="btn"
+          disabled={runM.isPending || !targets.trim()}
+          onClick={() => runM.mutate()}
+        >
+          {runM.isPending ? "Running…" : "Run Nmap"}
+        </button>
+        {runM.isError && <div className="text-red-600">Run failed</div>}
+      </div>
+      {lines.length > 0 && (
+        <pre className="card max-h-[40vh] overflow-auto text-sm font-mono leading-tight whitespace-pre-wrap">
+          {lines.join("\n")}
+        </pre>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,68 @@
+const API_BASE = (import.meta as any).env?.VITE_API_BASE || "";
+
+function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}
+
+export function wsUrl(path: string): string {
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  return `${proto}://${location.host}${API_BASE}${path}`;
+}
+
+export interface Project {
+  id: number;
+  name: string;
+  description?: string;
+}
+
+export async function listProjects(): Promise<Project[]> {
+  const res = await fetch(apiUrl("/projects"));
+  if (!res.ok) throw new Error("Failed to list projects");
+  return res.json();
+}
+
+export async function createProject(name: string, description?: string) {
+  const res = await fetch(apiUrl("/projects"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, description }),
+  });
+  if (!res.ok) throw new Error("Failed to create project");
+  return res.json();
+}
+
+interface StartScanInput {
+  project_id: number;
+  nmap_flags: string[];
+  targets: string[];
+  chunk_size: number;
+  concurrency: number;
+}
+
+export async function startScan(input: StartScanInput) {
+  const res = await fetch(apiUrl("/scans/start"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error("Failed to start scan");
+  return res.json();
+}
+
+interface RunNmapInput {
+  flags: string[];
+  targets: string[];
+}
+
+export async function runNmap(input: RunNmapInput): Promise<{ stdout: string }> {
+  const res = await fetch(apiUrl("/nmap/run"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,6 @@
+export type WSEvent =
+  | { event: "line"; batch_id: number; line: string }
+  | { event: "batch_start"; batch_id: number; targets: string[] }
+  | { event: "batch_complete"; batch_id: number; summary: { hosts_up: number; open_ports: number } }
+  | { event: "scan_complete"; scan_id: number }
+  | { event: "connected"; scan_id: number };


### PR DESCRIPTION
## Summary
- add NmapRunner component for ad-hoc scans
- expose new runNmap API helper
- hook NmapRunner into main app

## Testing
- `npm --prefix frontend run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a281d04f488321a0786687aa91ba9c