### PR TITLE
feat: Expand API to include parsed Nmap results

### DIFF
--- a/backend/api/routers.py
+++ b/backend/api/routers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from pathlib import Path
 import time
 import re
@@ -139,6 +140,20 @@ async def scans_start(payload: StartScanIn, db: AsyncSession = Depends(get_db)):
         concurrency=payload.concurrency,
     )
     return {"scan_id": scan_id, "status": "started"}
+
+@router.get("/scans/{scan_id}/hosts")
+async def list_scan_hosts(scan_id: int, db: AsyncSession = Depends(get_db)):
+    query = select(models.Host).where(models.Host.scan_id == scan_id)
+    rows = (await db.execute(query)).scalars().all()
+    return rows
+
+@router.get("/hosts/{host_id}")
+async def get_host_details(host_id: int, db: AsyncSession = Depends(get_db)):
+    query = select(models.Host).where(models.Host.id == host_id).options(selectinload(models.Host.ports))
+    row = (await db.execute(query)).scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="Host not found")
+    return row
 
 @router.post("/scans/{scan_id}/stop")
 async def scans_stop(scan_id: int):

--- a/backend/domain/xml_parser.py
+++ b/backend/domain/xml_parser.py
@@ -1,0 +1,68 @@
+import xml.etree.ElementTree as ET
+from typing import List
+from ..infra.models import Host, Port
+
+def parse_nmap_xml(xml_content: str) -> List[Host]:
+    """
+    Parses Nmap XML output and returns a list of Host objects.
+    These objects are not yet session-aware and must be added to a session
+    to be persisted.
+    """
+    hosts: List[Host] = []
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError:
+        # Handle empty or invalid XML
+        return []
+
+    for host_node in root.findall('host'):
+        status_node = host_node.find('status')
+        address_node = host_node.find('address')
+
+        if status_node is None or address_node is None:
+            continue
+
+        host_status = status_node.get('state')
+        if host_status != 'up':
+            continue
+
+        ip_address = address_node.get('addr')
+
+        hostname_node = host_node.find('hostnames/hostname')
+        hostname = hostname_node.get('name') if hostname_node is not None else None
+
+        host = Host(
+            address=ip_address,
+            hostname=hostname,
+            status=host_status,
+            ports=[]
+        )
+
+        for port_node in host_node.findall('ports/port'):
+            state_node = port_node.find('state')
+            if state_node is None or state_node.get('state') != 'open':
+                continue
+
+            port_id = port_node.get('portid')
+            protocol = port_node.get('protocol')
+            port_state = state_node.get('state')
+
+            service_node = port_node.find('service')
+            service_name = service_node.get('name') if service_node is not None else None
+            service_product = service_node.get('product') if service_node is not None else None
+            service_version = service_node.get('version') if service_node is not None else None
+
+            port = Port(
+                port_number=int(port_id),
+                protocol=protocol,
+                state=port_state,
+                service_name=service_name,
+                service_product=service_product,
+                service_version=service_version,
+            )
+            host.ports.append(port)
+
+        if host.ports:
+            hosts.append(host)
+
+    return hosts

--- a/frontend/src/components/HostDetails.tsx
+++ b/frontend/src/components/HostDetails.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { getHostDetails, type Port } from "../lib/api";
+
+export default function HostDetails({ hostId }: { hostId: number }) {
+  const hostQ = useQuery({
+    queryKey: ["host", hostId],
+    queryFn: () => getHostDetails(hostId),
+  });
+
+  if (hostQ.isLoading) return <div>Loading host details...</div>;
+  if (hostQ.isError) return <div className="text-red-600">Failed to load host details</div>;
+
+  const { address, hostname, status, ports } = hostQ.data;
+
+  return (
+    <div className="mt-4 card">
+      <h5 className="font-semibold">Details for {address}</h5>
+      <p>Hostname: {hostname || "N/A"}</p>
+      <p>Status: {status}</p>
+      <h6 className="font-semibold mt-2">Open Ports</h6>
+      <table className="table w-full">
+        <thead>
+          <tr>
+            <th>Port</th>
+            <th>Protocol</th>
+            <th>State</th>
+            <th>Service</th>
+            <th>Product</th>
+            <th>Version</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ports.map((port: Port) => (
+            <tr key={port.id}>
+              <td>{port.port_number}</td>
+              <td>{port.protocol}</td>
+              <td>{port.state}</td>
+              <td>{port.service_name}</td>
+              <td>{port.service_product}</td>
+              <td>{port.service_version}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/HostList.tsx
+++ b/frontend/src/components/HostList.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+import { listScanHosts, type Host } from "../lib/api";
+import { useState } from "react";
+import HostDetails from "./HostDetails";
+
+export default function HostList({ scanId }: { scanId: number }) {
+  const [selectedHostId, setSelectedHostId] = useState<number | null>(null);
+
+  const hostsQ = useQuery({
+    queryKey: ["hosts", scanId],
+    queryFn: () => listScanHosts(scanId),
+    refetchInterval: 5000,
+  });
+
+  if (hostsQ.isLoading) return <div>Loading hosts...</div>;
+  if (hostsQ.isError) return <div className="text-red-600">Failed to load hosts</div>;
+  if (hostsQ.data.length === 0) return null;
+
+  return (
+    <div className="mt-4">
+      <h4 className="font-semibold">Discovered Hosts</h4>
+      <ul className="list-disc list-inside">
+        {hostsQ.data.map((host: Host) => (
+          <li key={host.id}>
+            {host.address} ({host.hostname || "no hostname"}) - {host.status}
+            <button className="btn btn-sm ml-4" onClick={() => setSelectedHostId(host.id)}>
+              {selectedHostId === host.id ? "Hide Details" : "View Details"}
+            </button>
+          </li>
+        ))}
+      </ul>
+      {selectedHostId && <HostDetails hostId={selectedHostId} />}
+    </div>
+  );
+}

--- a/frontend/src/components/ScanList.tsx
+++ b/frontend/src/components/ScanList.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { listProjectScans, stopScan, type Scan } from "../lib/api";
 import BatchList from "./BatchList";
+import HostList from "./HostList";
 
 export default function ScanList({ projectId }: { projectId: number }) {
   const qc = useQueryClient();
@@ -48,6 +49,7 @@ export default function ScanList({ projectId }: { projectId: number }) {
                     )}
                   </div>
                   <BatchList scanId={scan.id} />
+                  <HostList scanId={scan.id} />
                 </div>
               ))}
             </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -109,3 +109,34 @@ export async function stopScan(scanId: number) {
   if (!res.ok) throw new Error("Failed to stop scan");
   return res.json();
 }
+
+export interface Port {
+  id: number;
+  port_number: number;
+  protocol: string;
+  state: string;
+  service_name?: string;
+  service_product?: string;
+  service_version?: string;
+}
+
+export interface Host {
+  id: number;
+  scan_id: number;
+  address: string;
+  hostname?: string;
+  status: string;
+  ports: Port[];
+}
+
+export async function listScanHosts(scanId: number): Promise<Host[]> {
+  const res = await fetch(apiUrl(`/scans/${scanId}/hosts`));
+  if (!res.ok) throw new Error("Failed to list scan hosts");
+  return res.json();
+}
+
+export async function getHostDetails(hostId: number): Promise<Host> {
+  const res = await fetch(apiUrl(`/hosts/${hostId}`));
+  if (!res.ok) throw new Error("Failed to get host details");
+  return res.json();
+}


### PR DESCRIPTION
This commit introduces a major feature enhancement by expanding the API to include parsed Nmap scan results.

The key changes are:

- **Database Schema:** Added `Host` and `Port` tables to the database to store detailed information about discovered hosts and their open ports.
- **XML Parser:** Implemented a new XML parser in `backend/domain/xml_parser.py` to extract host and port information from Nmap's XML output.
- **Scan Integration:** The scan coordinator has been updated to use the new parser to process scan results and save them to the database.
- **New API Endpoints:** Created new API endpoints (`/scans/{scan_id}/hosts` and `/hosts/{host_id}`) to expose the parsed scan results.
- **Frontend Integration:** The frontend has been updated to display the parsed results. This includes new components (`HostList.tsx` and `HostDetails.tsx`) and updates to the API client.