### PR TITLE
Use Gunicorn entrypoint and fix uvicorn docs

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -26,5 +26,5 @@ COPY backend/ /app/backend/
 
 USER app
 EXPOSE 8000
-CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "backend.main:app", "--bind", "0.0.0.0:8000", "--workers", "2"]
+CMD gunicorn -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:8000 --workers 2
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -59,7 +59,7 @@ A manual setup is suitable for developers who want to work on the frontend or ba
 
 5.  **Run the backend server:**
     ```bash
-    poetry run uvicorn backend.app:app --reload
+    poetry run uvicorn backend.main:app --reload
     ```
     The backend will be available at `http://localhost:8000`.
 


### PR DESCRIPTION
## Summary
- run backend container via `gunicorn` with Uvicorn worker
- document correct import for running FastAPI app manually

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3bfa1fbd08321a6607f783194ffa3