### PR TITLE
Verify Nmap availability in backend Docker build

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -20,7 +20,8 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels -r /app/requireme
 # Install Nmap and set capabilities for raw socket access
 RUN apt-get update && apt-get install -y --no-install-recommends nmap libcap2-bin \
     && rm -rf /var/lib/apt/lists/* \
-    && setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip $(command -v nmap)
+    && setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip $(command -v nmap) \
+    && nmap --version
 
 COPY backend/ /app/backend/
 


### PR DESCRIPTION
## Summary
- Ensure backend Dockerfile verifies Nmap installation by running `nmap --version`
- Retain slim install with apt cache cleanup

## Testing
- `pytest -q`
- `docker build -f docker/Dockerfile.backend --target runtime -t backend-test .` *(fails: command not found: docker)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a3bfa2f5c083219ace6c14347d24d4