### PR TITLE
feat: make output and nmap paths configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 # Example: postgresql://user:password@localhost:5432/nso
 NSO_DATABASE_URL=postgresql://user:password@localhost:5432/nso
 
-# Directory where scan outputs will be stored
-NSO_OUTPUT_DIR=/var/lib/nso/output
+# Directory where scan outputs will be stored (defaults to ./data/outputs)
+NSO_OUTPUT_DIR=./data/outputs
 
-# Path to the nmap executable
-NSO_NMAP_PATH=/usr/bin/nmap
+# Path to the nmap executable (defaults to 'nmap')
+NSO_NMAP_PATH=nmap
 

--- a/backend/api/routers.py
+++ b/backend/api/routers.py
@@ -3,10 +3,10 @@ from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, HTTPExce
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-from pathlib import Path
 import time
 import re
 from ..infra.db import SessionLocal
+from ..app.settings import settings
 from ..infra import models
 from ..infra.ws_hub import ws_manager
 from ..domain.scan_coordinator import start_scan
@@ -102,11 +102,11 @@ class NmapRunIn(BaseModel):
 @router.post("/nmap/run")
 async def nmap_run(payload: NmapRunIn):
     batch_id = int(time.time())
-    out_dir = Path("./data/tmp")
+    out_dir = settings.output_dir / "tmp"
     lines: list[str] = []
     stderr_path = out_dir / f"batch_{batch_id}.stderr.log"
     try:
-        async for line in run_nmap_batch(batch_id, payload.targets, payload.nmap_flags, out_dir):
+        async for line in run_nmap_batch(batch_id, payload.targets, payload.nmap_flags, out_dir=out_dir):
             lines.append(line)
     except Exception as e:
         err_text = ""

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -8,6 +8,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = REPO_ROOT / "data"
 DATA_DIR.mkdir(parents=True, exist_ok=True)  # ensure ./data exists for SQLite file
 
+
+def _default_output_dir() -> Path:
+    path = DATA_DIR / "outputs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
 def _default_sqlite_url() -> str:
     # Use forward slashes so SQLAlchemy parses it on Windows too
     db_path = (DATA_DIR / "nsorchestrator.db").as_posix()
@@ -18,6 +24,8 @@ class Settings(BaseSettings):
     # Override with NSO_DATABASE_URL in env or .env
     database_url: str = Field(default_factory=_default_sqlite_url)
     debug: bool = True
+    output_dir: Path = Field(default_factory=_default_output_dir)
+    nmap_path: str = "nmap"
 
     # Pydantic v2 settings config
     model_config = SettingsConfigDict(

--- a/backend/domain/runner.py
+++ b/backend/domain/runner.py
@@ -3,18 +3,23 @@ import asyncio
 from pathlib import Path
 from typing import AsyncIterator, Sequence
 
+from ..app.settings import settings
+
 async def run_nmap_batch(
     batch_id: int,
     targets: Sequence[str],
     nmap_flags: Sequence[str],
-    out_dir: Path,
+    out_dir: Path | None = None,
+    nmap_path: str | None = None,
 ) -> AsyncIterator[str]:
+    out_dir = out_dir or settings.output_dir
+    nmap_path = nmap_path or settings.nmap_path
     out_dir.mkdir(parents=True, exist_ok=True)
     xml_path = out_dir / f"batch_{batch_id}.xml"
     stdout_path = out_dir / f"batch_{batch_id}.stdout.log"
     stderr_path = out_dir / f"batch_{batch_id}.stderr.log"
 
-    cmd = ["nmap", *nmap_flags, "-oX", str(xml_path), *targets]
+    cmd = [nmap_path, *nmap_flags, "-oX", str(xml_path), *targets]
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       dockerfile: docker/Dockerfile.backend
     environment:
       NSO_DATABASE_URL: postgresql+psycopg://postgres:netscan@db:5432/netscan
-      NSO_OUTPUT_DIR: /data/outputs
-      NSO_NMAP_PATH: nmap
+      NSO_OUTPUT_DIR: /data/outputs  # default: ./data/outputs
+      NSO_NMAP_PATH: nmap           # default: nmap
     volumes:
       - outputs:/data/outputs
     depends_on:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,7 +21,7 @@ The `docker-compose.yml` file at the root of the project defines the services th
 
 -   **Build:** Built from `docker/Dockerfile.backend`.
 -   **Purpose:** Runs the FastAPI backend application.
--   **Environment:** Uses `NSO_DATABASE_URL`, `NSO_OUTPUT_DIR`, and `NSO_NMAP_PATH`.
+-   **Environment:** Uses `NSO_DATABASE_URL`, `NSO_OUTPUT_DIR` (default `./data/outputs`), and `NSO_NMAP_PATH` (default `nmap`).
 -   **Volumes:** Mounts the named volume `outputs` at `/data/outputs` for persistent Nmap scan results.
 -   **Depends On:** Depends on the `db` service, so Docker Compose starts the database first.
 -   **Capabilities:** `cap_add: [NET_RAW, NET_ADMIN]` allows Nmap to perform scans requiring elevated network privileges.

--- a/docs/install.md
+++ b/docs/install.md
@@ -85,8 +85,8 @@ A manual setup is suitable for developers who want to work on the frontend or ba
 
 The application is configured using environment variables. The backend expects the following variables (with the `NSO_` prefix):
 
--   `NSO_DATABASE_URL`: The connection string for the PostgreSQL database.
--   `NSO_OUTPUT_DIR`: The directory where Nmap scan outputs are stored.
--   `NSO_NMAP_PATH`: The path to the `nmap` executable.
+    -   `NSO_DATABASE_URL`: The connection string for the PostgreSQL database.
+    -   `NSO_OUTPUT_DIR`: Directory where Nmap scan outputs are stored (default `./data/outputs`).
+    -   `NSO_NMAP_PATH`: Path to the `nmap` executable (default `nmap`).
 
 These are set in the `docker-compose.yml` for the Docker setup. For a manual setup, you can use a `.env` file or set them in your shell.


### PR DESCRIPTION
## Summary
- add `output_dir` and `nmap_path` to app settings with defaults
- use configured paths in Nmap runner, scan coordinator and API
- document `NSO_OUTPUT_DIR` and `NSO_NMAP_PATH` defaults in compose and docs

## Testing
- `python -m py_compile backend/app/settings.py backend/domain/runner.py backend/domain/scan_coordinator.py backend/api/routers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3bfa7ad1c8321802e929472147ba4