### PR TITLE
docs: update docker instructions

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
 # Docker Documentation
 
-This document explains the Docker setup for the NetScanOrchestrator project. Docker is the recommended way to run the application, as it simplifies dependency management and deployment.
+This document explains the Docker setup for the NetScanOrchestrator project. Docker is the recommended way to run the application, as it simplifies dependency management and deployment. Backend dependencies are managed with `requirements.txt` instead of Poetry.
 
 ## `docker-compose.yml`
 
@@ -28,8 +28,8 @@ The `docker-compose.yml` file at the root of the project defines the services th
 
 #### `gateway`
 
--   **Build:** Built from `docker/Dockerfile.gateway`.
--   **Purpose:** Serves the frontend assets and proxies API and WebSocket traffic to the `api` service.
+-   **Build:** Built from `docker/Dockerfile.gateway`, which first compiles the frontend with Node and then serves the static files with Nginx.
+-   **Purpose:** Serves the built frontend assets and proxies API and WebSocket traffic to the `api` service.
 -   **Ports:** Exposes port `80` on the host machine.
 -   **Configuration:** Includes the Nginx configuration from `ops/nginx.conf`.
 -   **Depends On:** Depends on the `api` service.
@@ -48,20 +48,20 @@ This Dockerfile defines the image for the `api` service.
 
 
 -   **Base Image:** Uses `python:3.12-slim`.
--   **Dependencies:** Copies `requirements.txt` and builds wheels with `pip wheel` in a separate build stage. The runtime stage installs these wheels without network access.
--   **Nmap:** Installs the `nmap` package so the backend can execute network scans.
+-   **Dependencies:** Copies `requirements.txt` and builds wheels with `pip wheel` in a separate build stage. The runtime stage installs these wheels without network access. The project uses `requirements.txt` instead of Poetry for dependency management.
+-   **Nmap:** After the Issue 4 fix, the Dockerfile explicitly installs the `nmap` package and sets the necessary capabilities so the backend can execute network scans.
 -   **Application Code:** Copies the backend source into the image and runs it with `gunicorn` and `uvicorn` workers.
 
 ### `docker/Dockerfile.gateway`
 
-This Dockerfile defines the image for the `gateway` service. It's a multi-stage build.
+This Dockerfile defines the image for the `gateway` service. It's a multi-stage build that compiles the frontend with Node and then serves the static files with Nginx.
 
 -   **Frontend Build Stage:**
     -   **Base Image:** `node:20-slim`
     -   **Purpose:** This stage builds the static frontend assets.
     -   It installs the npm dependencies and runs the `npm run build` script.
 -   **Final Stage:**
-    -   **Base Image:** `nginx:1.27-alpine`
-    -   **Purpose:** This stage serves the built frontend.
+    -   **Base Image:** `public.ecr.aws/y9w1g0t0/nginxinc/nginx-unprivileged:1.21-alpine`
+    -   **Purpose:** This stage serves the built frontend with Nginx.
     -   It copies the built assets from the frontend build stage.
-    -   It also copies the `ops/nginx.conf` file to configure nginx.
+    -   It also copies the `ops/nginx.conf` file to configure Nginx.


### PR DESCRIPTION
## Summary
- document gateway service instead of nginx
- clarify Node build and Nginx static serving
- note requirements.txt usage and explicit Nmap install after Issue 4

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_68a3bfaacd448321bd96a80618696ae7