### PR TITLE
Add environment template and document usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+## Example environment configuration for NetScanOrchestrator-NG
+## Copy this file to `.env` and adjust values for your setup
+
 # Connection string for the NSO database
 # Example: postgresql://user:password@localhost:5432/nso
 NSO_DATABASE_URL=postgresql://user:password@localhost:5432/nso

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,6 +2,8 @@
 
 This document explains the Docker setup for the NetScanOrchestrator project. Docker is the recommended way to run the application, as it simplifies dependency management and deployment.
 
+Before starting, copy the provided `.env.example` file to `.env` and adjust values for `NSO_DATABASE_URL`, `NSO_OUTPUT_DIR`, and `NSO_NMAP_PATH` so that Docker Compose can load them.
+
 ## `docker-compose.yml`
 
 The `docker-compose.yml` file at the root of the project defines the services that make up the application.

--- a/docs/install.md
+++ b/docs/install.md
@@ -89,4 +89,10 @@ The application is configured using environment variables. The backend expects t
 -   `NSO_OUTPUT_DIR`: The directory where Nmap scan outputs are stored.
 -   `NSO_NMAP_PATH`: The path to the `nmap` executable.
 
+A `.env.example` file at the project root provides sample values for these variables. Copy it to `.env` and customize it for your environment:
+
+```bash
+cp .env.example .env
+```
+
 These are set in the `docker-compose.yml` for the Docker setup. For a manual setup, you can use a `.env` file or set them in your shell.


### PR DESCRIPTION
## Summary
- add example `.env` template with database, output, and nmap variables
- document copying `.env.example` in installation and Docker guides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3bfba2b908321baf304605a69ddf4