### PR TITLE
build: run nmap version check before setcap

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -19,9 +19,9 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels -r /app/requireme
 
 # Install Nmap and set capabilities for raw socket access
 RUN apt-get update && apt-get install -y --no-install-recommends nmap libcap2-bin \
-    && rm -rf /var/lib/apt/lists/* \
+    && nmap --version \
     && setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip $(command -v nmap) \
-    && nmap --version
+    && rm -rf /var/lib/apt/lists/*
 
 COPY backend/ /app/backend/
 


### PR DESCRIPTION
## Summary
- move `nmap --version` before `setcap` in backend Dockerfile to avoid raw socket requirement during build

## Testing
- `pytest`
- `docker build -f docker/Dockerfile.backend --progress=plain -t netscan-backend:test .` *(fails: docker not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a3cd209f2c83218aa38b9fb48a8adc