### PR TITLE
Add Vitest testing setup and sample frontend tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port 5173",
+    "test": "vitest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.85.3",
@@ -20,9 +21,18 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.21",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "jsdom": "^24.1.0",
+    "msw": "^1.2.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.4",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^1.6.0"
+  },
+  "vitest": {
+    "environment": "jsdom",
+    "setupFiles": "./src/__tests__/setup.ts"
   }
 }

--- a/frontend/src/__tests__/ProjectDashboardPage.test.tsx
+++ b/frontend/src/__tests__/ProjectDashboardPage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { vi } from 'vitest';
+import ProjectDashboardPage from '../pages/ProjectDashboardPage';
+import React from 'react';
+
+vi.mock('../components/TargetInput', () => ({
+  default: ({ onTargetsChanged, onChunkSizeChanged }: any) => {
+    onTargetsChanged(['192.0.2.1']);
+    onChunkSizeChanged(1);
+    return <div>TargetInputMock</div>;
+  },
+}));
+
+vi.mock('../components/ScanList', () => ({
+  default: () => <div>ScanListMock</div>,
+}));
+
+let startScanCalled = false;
+const server = setupServer(
+  http.post('/api/scans/start', async ({ request }) => {
+    startScanCalled = true;
+    return HttpResponse.json({ id: 1 });
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => { server.resetHandlers(); startScanCalled = false; });
+afterAll(() => server.close());
+
+test('starts a scan via API', async () => {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/projects/1']}>
+        <Routes>
+          <Route path="/projects/:projectId" element={<ProjectDashboardPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  const button = await screen.findByRole('button', { name: /start scan/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(startScanCalled).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/ProjectsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectsPage.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import Projects from '../pages/ProjectsPage';
+
+const server = setupServer(
+  http.get('/api/projects', () => {
+    return HttpResponse.json([
+      { id: 1, name: 'Project Alpha', description: 'First' }
+    ]);
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test('renders project list from API', async () => {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Projects />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  expect(await screen.findByText('Project Alpha')).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- configure Vitest in package.json with jsdom environment and test script
- add sample MSW-backed tests for project listing and starting a scan
- include testing setup file with jest-dom matchers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3cd32a84883219a4dcdc1552df23d