### PR TITLE
Add MkDocs documentation build and link checking

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install documentation dependencies
+        run: pip install mkdocs mkdocs-myst-parser mkdocs-linkcheck
+      - name: Build documentation
+        run: mkdocs build --strict
+      - name: Check documentation links
+        run: mkdocs linkcheck
+
   build-and-push:
     runs-on: ubuntu-latest
     permissions:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# NetScan Orchestrator NG Documentation
+
+Welcome to the documentation for NetScan Orchestrator NG. Use the navigation to explore architecture, installation, usage, and API details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,20 @@
+site_name: NetScan Orchestrator NG
+docs_dir: docs
+site_dir: site
+nav:
+  - Home: index.md
+  - Architecture: ARCHITECTURE.md
+  - Installation: install.md
+  - Usage: usage.md
+  - Backend: backend.md
+  - Frontend: frontend.md
+  - Docker: docker.md
+  - API: api.md
+plugins:
+  - search
+  - linkcheck
+  - myst-parser
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ httpx = "^0.27.0"
 pytest = "^8.0.0"
 async-asgi-testclient = "^1.4.11"
 pytest-timeout = "^2.4.0"
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = "^1.6"
+mkdocs-myst-parser = "^1.0"
+mkdocs-linkcheck = "^1.0"


### PR DESCRIPTION
## Summary
- configure MkDocs with MyST and link checking for Markdown docs
- add docs dependencies and index page
- verify docs in CI with strict build and link check

## Testing
- `pytest`
- `mkdocs build --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3cd538eb08321aa9350a5a3dddee9