### PR TITLE
feat: add quick scan route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,14 +12,19 @@ export default function App() {
         <h1 className="text-2xl font-semibold">
           <Link to="/">NetScan Orchestrator</Link>
         </h1>
-        <a
-          className="btn"
-          href="https://github.com/cornish337/NetScanOrchestrator-NG"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Repo
-        </a>
+        <nav className="flex items-center gap-3">
+          <Link className="btn" to="/quick-scan">
+            Quick Scan
+          </Link>
+          <a
+            className="btn"
+            href="https://github.com/cornish337/NetScanOrchestrator-NG"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Repo
+          </a>
+        </nav>
       </header>
 
       <Routes>
@@ -29,6 +34,7 @@ export default function App() {
         <Route path="/projects/:projectId" element={<ProjectDashboardPage />} />
         <Route path="/ip/:address" element={<IPDetailsPage />} />
         <Route path="/runner" element={<NmapRunner />} />
+        <Route path="/quick-scan" element={<NmapRunner />} />
       </Routes>
     </div>
   );

--- a/frontend/src/__tests__/QuickScanLink.test.tsx
+++ b/frontend/src/__tests__/QuickScanLink.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { expect, test } from 'vitest';
+import App from '../App';
+
+test('Quick Scan link navigates to NmapRunner', () => {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  const link = screen.getByRole('link', { name: /quick scan/i });
+  fireEvent.click(link);
+  expect(screen.getByRole('heading', { name: /run nmap/i })).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Quick Scan shortcut to header and route that renders the existing NmapRunner form
- add regression test for Quick Scan navigation

## Testing
- `pre-commit run --files frontend/src/App.tsx frontend/src/__tests__/QuickScanLink.test.tsx` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `npm test` *(fails: Failed to load url @playwright/test; TypeError: Cannot read properties of undefined (reading 'post'); document is not defined)*


------
https://chatgpt.com/codex/tasks/task_b_68a4043a3cf083219d3b07cbf930d4e1