### PR TITLE
feat: add global scans listing and debug route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import ProjectDashboardPage from "./pages/ProjectDashboardPage";
 import NewProjectPage from "./pages/NewProjectPage";
 import IPDetailsPage from "./pages/IPDetailsPage";
 import NmapRunner from "./components/NmapRunner";
+import DebugDashboardPage from "./pages/DebugDashboardPage";
 
 export default function App() {
   return (
@@ -15,6 +16,9 @@ export default function App() {
         <nav className="flex items-center gap-3">
           <Link className="btn" to="/quick-scan">
             Quick Scan
+          </Link>
+          <Link className="btn" to="/debug">
+            Debug
           </Link>
           <a
             className="btn"
@@ -35,6 +39,7 @@ export default function App() {
         <Route path="/ip/:address" element={<IPDetailsPage />} />
         <Route path="/runner" element={<NmapRunner />} />
         <Route path="/quick-scan" element={<NmapRunner />} />
+        <Route path="/debug" element={<DebugDashboardPage />} />
       </Routes>
     </div>
   );

--- a/frontend/src/__tests__/ProjectDashboardPage.test.tsx
+++ b/frontend/src/__tests__/ProjectDashboardPage.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { setupServer } from 'msw/node';
-import { http, HttpResponse } from 'msw';
-import { vi } from 'vitest';
+import { rest, HttpResponse } from 'msw';
+import { vi, beforeAll, afterEach, afterAll, expect, test, waitFor } from 'vitest';
 import ProjectDashboardPage from '../pages/ProjectDashboardPage';
 import React from 'react';
 
@@ -21,7 +21,7 @@ vi.mock('../components/ScanList', () => ({
 
 let startScanCalled = false;
 const server = setupServer(
-  http.post('/api/scans/start', async ({ request }) => {
+  rest.post('/api/scans/start', async ({ request }) => {
     startScanCalled = true;
     return HttpResponse.json({ id: 1 });
   })

--- a/frontend/src/__tests__/ProjectsPage.test.tsx
+++ b/frontend/src/__tests__/ProjectsPage.test.tsx
@@ -2,14 +2,18 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { setupServer } from 'msw/node';
-import { http, HttpResponse } from 'msw';
+import { rest, HttpResponse } from 'msw';
+import { beforeAll, afterEach, afterAll, expect, test } from 'vitest';
 import Projects from '../pages/ProjectsPage';
 
 const server = setupServer(
-  http.get('/api/projects', () => {
+  rest.get('/api/projects', () => {
     return HttpResponse.json([
       { id: 1, name: 'Project Alpha', description: 'First' }
     ]);
+  }),
+  rest.get('/api/scans', () => {
+    return HttpResponse.json({ scans: [] });
   })
 );
 

--- a/frontend/src/__tests__/QuickScanLink.test.tsx
+++ b/frontend/src/__tests__/QuickScanLink.test.tsx
@@ -1,8 +1,19 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
-import { expect, test } from 'vitest';
+import { expect, test, beforeAll, afterEach, afterAll } from 'vitest';
+import { setupServer } from 'msw/node';
+import { rest, HttpResponse } from 'msw';
 import App from '../App';
+
+const server = setupServer(
+  rest.get('/api/projects', () => HttpResponse.json([])),
+  rest.get('/api/scans', () => HttpResponse.json({ scans: [] }))
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 test('Quick Scan link navigates to NmapRunner', () => {
   const qc = new QueryClient();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,6 +81,16 @@ export async function listProjectScans(projectId: number): Promise<Scan[]> {
   return res.json();
 }
 
+export interface ListAllScansResponse {
+  scans: Scan[];
+}
+
+export async function listAllScans(): Promise<ListAllScansResponse> {
+  const res = await fetch(apiUrl("/scans"));
+  if (!res.ok) throw new Error("Failed to list scans");
+  return res.json();
+}
+
 export interface Batch {
   id: number;
   scan_id: number;

--- a/frontend/src/pages/DebugDashboardPage.tsx
+++ b/frontend/src/pages/DebugDashboardPage.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { listAllScans } from "../lib/api";
+
+export default function DebugDashboardPage() {
+  const scansQ = useQuery({
+    queryKey: ["debug-scans"],
+    queryFn: listAllScans,
+    staleTime: 5_000,
+  });
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Debug Dashboard</h1>
+      {scansQ.isLoading ? (
+        <div>Loading scans…</div>
+      ) : scansQ.isError ? (
+        <div className="text-red-600">Failed to load scans</div>
+      ) : (
+        <pre className="text-sm overflow-auto">
+          {JSON.stringify(scansQ.data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { listProjects, type Project } from "../lib/api";
+import { listProjects, listAllScans, type Project, type Scan } from "../lib/api";
 
 export default function Projects() {
   const projectsQ = useQuery({
@@ -8,6 +8,21 @@ export default function Projects() {
     queryFn: listProjects,
     staleTime: 5_000,
   });
+
+  const scansQ = useQuery({
+    queryKey: ["all-scans"],
+    queryFn: listAllScans,
+    staleTime: 5_000,
+  });
+
+  const scanData = scansQ.data?.scans ?? [];
+  const statusCounts = scanData.reduce(
+    (acc, s: Scan) => {
+      acc[s.status] = (acc[s.status] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
 
   return (
     <div className="max-w-5xl mx-auto p-6 space-y-6">
@@ -17,6 +32,24 @@ export default function Projects() {
           New Project
         </Link>
       </header>
+
+      <section className="card space-y-2">
+        <h2 className="text-lg font-semibold">Scan Summary</h2>
+        {scansQ.isLoading ? (
+          <div>Loading scans…</div>
+        ) : scansQ.isError ? (
+          <div className="text-red-600">Failed to load scans</div>
+        ) : (
+          <div className="flex gap-4 flex-wrap">
+            <div>Total: {scanData.length}</div>
+            {Object.entries(statusCounts).map(([status, count]) => (
+              <div key={status}>
+                {status}: {count}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
 
       <section className="card space-y-4">
         {projectsQ.isLoading ? (


### PR DESCRIPTION
## Summary
- expose `listAllScans` API wrapper and types
- add `/debug` route and navigation link
- display scan summary on home page

## Testing
- `npm test` *(fails: Cannot find module '@playwright/test'; document is not defined)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a411ce6e6c832192ed0c7326f8324d