### PR TITLE
Use configurable database URL

### DIFF
--- a/backend/infra/db.py
+++ b/backend/infra/db.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.orm import DeclarativeBase
-from sqlalchemy import event, text
+from sqlalchemy import event
 
-DATABASE_URL = "sqlite+aiosqlite:///./data/state.db"
+from backend.app.settings import settings
 
 class Base(DeclarativeBase):
     pass
 
 engine = create_async_engine(
-    DATABASE_URL,
+    settings.database_url,
     future=True,
 )
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,8 +49,8 @@ A manual setup is suitable for developers who want to work on the frontend or ba
     poetry install
     ```
 
-3.  **Set up the database:**
-    You'll need a running PostgreSQL server. Configure the `NSO_DATABASE_URL` environment variable to point to your database.
+3.  **Configure the database connection:**
+    By default, the backend stores data in a local SQLite file under `./data`. To use a different database such as PostgreSQL, set the `NSO_DATABASE_URL` environment variable to your connection string.
 
 4.  **Run database migrations:**
     ```bash
@@ -85,7 +85,7 @@ A manual setup is suitable for developers who want to work on the frontend or ba
 
 The application is configured using environment variables. The backend expects the following variables (with the `NSO_` prefix):
 
-    -   `NSO_DATABASE_URL`: The connection string for the PostgreSQL database.
+    -   `NSO_DATABASE_URL`: The database connection string (defaults to a local SQLite file).
     -   `NSO_OUTPUT_DIR`: Directory where Nmap scan outputs are stored (default `./data/outputs`).
     -   `NSO_NMAP_PATH`: Path to the `nmap` executable (default `nmap`).
 


### PR DESCRIPTION
## Summary
- use `settings.database_url` for SQLAlchemy engine and sessions
- document `NSO_DATABASE_URL` environment variable for configuring the database

## Testing
- `pytest` (no tests ran)
- `pre-commit run --files backend/infra/db.py docs/install.md` *(fails: pre-commit not installed and could not be installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68a4a8a6f2a48321809637d5e5cf4ab8